### PR TITLE
added missing product id to logging string

### DIFF
--- a/bin/amazon/amazon_products_to_trec.py
+++ b/bin/amazon/amazon_products_to_trec.py
@@ -74,7 +74,7 @@ def main():
 
                 product_document = io_utils.tokenize_text(product_document)
 
-                logging.debug('Product %s has description of %d tokens.',
+                logging.debug('Product %s has description of %d tokens.', product_id,
                               len(product_document))
 
                 writer.write_document(


### PR DESCRIPTION
In the logs I found a bunch of errors, all coming from the same line. Assuming the line below was correct, I edited the "broken" line to be analogous.
                logging.debug(
                    'Filtering product %s due to missing description.',
                    product_id)
